### PR TITLE
Add support for `permissions` authentication option

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ app.get('/auth/discord/callback', passport.authenticate('discord', {
 });
 ```
 
+If using the `bot` scope, the `permissions` option can be set to indicate
+specific permissions your bot needs on the server ([permission codes](https://discordapp.com/developers/docs/topics/permissions)):
+
+```javascript
+app.get("/auth/discord", passport.authenticate("discord", {permissions: 66321471}));
+```
+
 
 ## Examples
 An Express server example can be found in the `/example` directory. Be sure to `npm install` in that directory to get the dependencies.

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -102,6 +102,21 @@ Strategy.prototype.checkScope = function(scope, accessToken, cb) {
     }
 }
 
+/**
+ * Return extra parameters to be included in the authorization request.
+ *
+ * @param {Object} options
+ * @return {Object}
+ * @api protected
+ */
+Strategy.prototype.authorizationParams = function(options) {
+    var params = {};
+    if (typeof options.permissions !== "undefined") {
+        params.permissions = options.permissions;
+    }
+    return params;
+};
+
 
 /**
  * Expose `Strategy`.


### PR DESCRIPTION
https://discordapp.com/developers/docs/topics/permissions

usage:

```
app.get("/auth/discord", passport.authenticate("discord", {permissions: 66321471}));
```