### PR TITLE
Delay fetching guilds

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -16,6 +16,7 @@ var OAuth2Strategy      = require('passport-oauth2')
  * @property {string} [authorizationURL="https://discord.com/api/oauth2/authorize"]
  * @property {string} [tokenURL="https://discord.com/api/oauth2/token"]
  * @property {string} [scopeSeparator=" "]
+ * @property {number} [scopeDelay=0]
  */
 /**
  * `Strategy` constructor.
@@ -34,6 +35,7 @@ var OAuth2Strategy      = require('passport-oauth2')
  *   - `callbackURL`    URL that discord will redirect to after auth
  *   - `scope`          Array of permission scopes to request
  *                      Check the official documentation for valid scopes to pass as an array.
+ *   - `scopeDelay`     Delays the scope information requests (connections, guilds) to avoid rate limiting.
  * 
  * @constructor
  * @param {StrategyOptions} options
@@ -49,6 +51,7 @@ function Strategy(options, verify) {
     OAuth2Strategy.call(this, options, verify);
     this.name = 'discord';
     this._oauth2.useAuthorizationHeaderforGET(true);
+    this.scopeDelay = options.scopeDelay || 0;
 }
 
 /**
@@ -103,17 +106,20 @@ Strategy.prototype.userProfile = function(accessToken, done) {
 };
 
 Strategy.prototype.checkScope = function(scope, accessToken, cb) {
+    var self = this;
     if (this._scope && this._scope.indexOf(scope) !== -1) {
-        this._oauth2.get('https://discord.com/api/users/@me/' + scope, accessToken, function(err, body, res) {
-            if (err) return cb(new InternalOAuthError('Failed to fetch user\'s ' + scope, err));
-            try {
-                var json = JSON.parse(body);
-            }
-            catch (e) {
-                return cb(new Error('Failed to parse user\'s ' + scope));
-            }
-            cb(null, json);
-        });
+        setTimeout(function() {
+            self._oauth2.get('https://discord.com/api/users/@me/' + scope, accessToken, function(err, body, res) {
+                if (err) return cb(new InternalOAuthError('Failed to fetch user\'s ' + scope, err));
+                try {
+                    var json = JSON.parse(body);
+                }
+                catch (e) {
+                    return cb(new Error('Failed to parse user\'s ' + scope));
+                }
+                cb(null, json);
+            });
+        }, self.scopeDelay)
     } else {
         cb(null, null);
     }

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -119,7 +119,7 @@ Strategy.prototype.checkScope = function(scope, accessToken, cb) {
                 }
                 cb(null, json);
             });
-        }, self.scopeDelay)
+        }, self.scopeDelay);
     } else {
         cb(null, null);
     }


### PR DESCRIPTION
When experiencing a lot of requests, you sometimes get rate limited on fetching guilds.
This allows you to add a scopeDelay to avoid it.
Solves issue #27 